### PR TITLE
ci: update consistency runner volume label

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on:
       - runs-on=${{ github.run_id }}
       - family=m7a.24xlarge
-      - disk=large
+      - volume=80gb
 
     steps:
       - name: Checkout current repo


### PR DESCRIPTION
Updates the consistency workflow runner labels from the old `disk=large` syntax to `volume=80gb`, matching the current runs-on label format used by OpenVM workflows.